### PR TITLE
Fix errors

### DIFF
--- a/src/Synetic/JsonApiClient/ResponseParser.php
+++ b/src/Synetic/JsonApiClient/ResponseParser.php
@@ -17,17 +17,17 @@ class ResponseParser implements ResponseParserInterface {
    */
   public function responseHasErrors(Response $response) {
     if ($response->getStatusCode() < 200 || $response->getStatusCode() > 299) {
-      return TRUE;
+      return true;
     }
 
     $response->getBody()->rewind();
-    $body = json_decode($response->getBody()->getContents(), TRUE);
+    $body = json_decode($response->getBody()->getContents(), true);
 
     if (is_array($body) && array_key_exists('errors', $body)) {
-      return TRUE;
+      return true;
     }
 
-    return FALSE;
+    return false;
   }
 
   /**

--- a/src/Synetic/JsonApiClient/ResponseParser.php
+++ b/src/Synetic/JsonApiClient/ResponseParser.php
@@ -16,7 +16,7 @@ class ResponseParser implements ResponseParserInterface {
    * {@inheritdoc}
    */
   public function responseHasErrors(Response $response) {
-    if ($response->getStatusCode() !== 200) {
+    if ($response->getStatusCode() < 200 || $response->getStatusCode() > 299) {
       return true;
     }
 

--- a/src/Synetic/JsonApiClient/ResponseParser.php
+++ b/src/Synetic/JsonApiClient/ResponseParser.php
@@ -23,7 +23,7 @@ class ResponseParser implements ResponseParserInterface {
     $response->getBody()->rewind();
     $body = json_decode($response->getBody()->getContents(), true);
 
-    if (array_key_exists('errors', $body)) {
+    if (is_array($body) && array_key_exists('errors', $body)) {
       return true;
     }
 

--- a/src/Synetic/JsonApiClient/ResponseParser.php
+++ b/src/Synetic/JsonApiClient/ResponseParser.php
@@ -17,17 +17,17 @@ class ResponseParser implements ResponseParserInterface {
    */
   public function responseHasErrors(Response $response) {
     if ($response->getStatusCode() < 200 || $response->getStatusCode() > 299) {
-      return true;
+      return TRUE;
     }
 
     $response->getBody()->rewind();
-    $body = json_decode($response->getBody()->getContents(), true);
+    $body = json_decode($response->getBody()->getContents(), TRUE);
 
     if (is_array($body) && array_key_exists('errors', $body)) {
-      return true;
+      return TRUE;
     }
 
-    return false;
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
In case of -for example - a successful create (201) or delete (204), the responseHasErrors() method returned TRUE. However 2xx status codes are representing a successful request being made.